### PR TITLE
Refactor android-arm docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && apt-get -y -f install \
     bash \

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,12 @@ all:
 	done
 
 base:
-	$(DOCKER) build -t $(IMAGE):base .
+	$(DOCKER) build -t $(PROJECT)/$(IMAGE):base .
 
 $(PLATFORMS): base
-	$(DOCKER) build -t $(IMAGE):$@ -f docker/$@.Dockerfile docker
+	$(DOCKER) build -t $(PROJECT)/$(IMAGE):$@ -f docker/$@.Dockerfile docker
 
 push:
-	docker tag cross-compiler:$(PLATFORM) $(PROJECT)/cross-compiler:$(PLATFORM)
 	docker push $(PROJECT)/cross-compiler:$(PLATFORM)
 
 push-all:
@@ -45,7 +44,6 @@ push-all:
 
 pull:
 	docker pull $(PROJECT)/cross-compiler:$(PLATFORM)
-	docker tag $(PROJECT)/cross-compiler:$(PLATFORM) cross-compiler:$(PLATFORM)
 
 pull-all:
 	for i in $(PLATFORMS); do \

--- a/docker/android-arm.Dockerfile
+++ b/docker/android-arm.Dockerfile
@@ -1,23 +1,28 @@
-FROM cross-compiler:base
+FROM elementumorg/cross-compiler:base as ndk
+WORKDIR /ndk
 
-ENV CROSS_TRIPLE arm-linux-androideabi
+ENV NDK android-ndk-r20b
+RUN wget -nv https://dl.google.com/android/repository/${NDK}-linux-x86_64.zip
+RUN unzip ${NDK}-linux-x86_64.zip ${NDK}/toolchains/llvm/prebuilt/linux-x86_64/* 1>log 2>err 
+RUN ln -s ${NDK}/toolchains/llvm/prebuilt/linux-x86_64/ toolchain
+
+FROM elementumorg/cross-compiler:base as base
+
+ENV CROSS_TRIPLE armv7a-linux-androideabi21
 ENV CROSS_ROOT /usr/${CROSS_TRIPLE}
-ENV PATH ${PATH}:${CROSS_ROOT}/bin:${CROSS_ROOT}/go/bin
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
 ENV LD_LIBRARY_PATH ${CROSS_ROOT}/lib:${LD_LIBRARY_PATH}
 ENV PKG_CONFIG_PATH ${CROSS_ROOT}/lib/pkgconfig:${PKG_CONFIG_PATH}
 
-RUN apt-get update && apt-get install -y python
-
-ENV NDK android-ndk-r20b
-
-RUN set -ex && \
-    mkdir -p /build && \
-    cd /build && \
-    wget -nv https://dl.google.com/android/repository/${NDK}-linux-x86_64.zip && \
-    unzip ${NDK}-linux-x86_64.zip 1>log 2>err && \
-    cd ${NDK} && \
-    ./build/tools/make_standalone_toolchain.py --arch=arm --api=21 --install-dir=${CROSS_ROOT} && \
-    cd / && rm -rf /build
+COPY --from=ndk /ndk/toolchain/arm-linux-androideabi/bin/ld ${CROSS_ROOT}/bin/
+COPY --from=ndk /ndk/toolchain/bin/clang++ /ndk/toolchain/bin/clang /ndk/toolchain/bin/${CROSS_TRIPLE}-clang* ${CROSS_ROOT}/bin/
+COPY --from=ndk /ndk/toolchain/bin/arm-linux-androideabi-ar ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar
+COPY --from=ndk /ndk/toolchain/bin/arm-linux-androideabi-ranlib ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ranlib
+COPY --from=ndk /ndk/toolchain/lib/gcc ${CROSS_ROOT}/lib/gcc/
+COPY --from=ndk /ndk/toolchain/lib64/libc++.so.1 ${CROSS_ROOT}/lib64/
+COPY --from=ndk /ndk/toolchain/lib64/clang ${CROSS_ROOT}/lib64/clang/
+COPY --from=ndk /ndk/toolchain/sysroot/usr/include ${CROSS_ROOT}/sysroot/usr/include/
+COPY --from=ndk /ndk/toolchain/sysroot/usr/lib/arm-linux-androideabi ${CROSS_ROOT}/sysroot/usr/lib/arm-linux-androideabi
 
 RUN cd ${CROSS_ROOT}/bin && \
-    ln -s ${CROSS_TRIPLE}-clang ${CROSS_TRIPLE}-cc
+    ln -s ${CROSS_TRIPLE}-clang ${CROSS_TRIPLE}-gcc


### PR DESCRIPTION
This PR introduces a couple of improvements:
 - Updated base image 
 - Unified image tags (`elementumorg/cross-compiler:base` instead of `cross-compiler:base`)
 - Dockerfile uses [multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to improve performance and minimize resulting image
 - Resulting image is approx. 3 times smaller (900mb instead of 2700mb)
 
I've tested it with [ElementumOrg/libtorrent-go](https://github.com/ElementumOrg/libtorrent-go) and build succeeded.

This is a draft PR, only `android-arm` is refactored, but I want to work on all other images as well.
Let me know what you think.